### PR TITLE
Setting cron jobs without cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: cpp
 sudo: required
 
 before_install:
+  - if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then (rm -rf build antlr/build antlr/install) fi
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
   - sudo apt-get install -qq g++-6


### PR DESCRIPTION
Parce que le cache c'est bien, mais parce que ça peut parfois jouer des tours, des builds périodiques se déclencheront en supprimant le cache pour tester une build totalement clean